### PR TITLE
style: align with Go version terminology and common conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Bump-Go Action
 
-This GitHub Action auto-creates a PR that bumps the Go version to the latest available LTS version and updates the standard libraries in your project.
+This GitHub Action auto-creates a PR that bumps the Go version to the latest available stable version and updates the standard libraries in your project.
 
 ## Features
 
 - Determines the current Go version from a specified file or direct version input.
-- Checks if the current Go version is part of an LTS release.
-- If the current Go version is not part of an LTS release, the action fails.
-- If the current Go version is part of an LTS release but is not the latest patch version, the action bumps the Go version to the latest patch version.
+- Checks if the current Go version is part of a major (stable) release.
+- If the current Go version is not part of a major release, the action fails.
+- If the current Go version is part of a major release but is not the latest patch version, the action bumps the Go version to the latest patch version.
 - Updates all Go standard libraries to their latest versions.
 - Commits these changes and pushes them to a new branch.
 - Creates a pull request for these changes.

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'bump-go'
-description: 'Auto-bumps Go version to the latest available LTS version and updates stdlibs'
+description: 'Auto-bumps Go version to the latest available major version and updates stdlibs'
 author: 'dduzgun-security'
 
 inputs:
@@ -43,53 +43,54 @@ runs:
 
         echo "Building with Go ${GO_VERSION}"
         echo "go-version=${GO_VERSION}" >> "${GITHUB_OUTPUT}"
-        GO_MINOR_VERSION=${GO_VERSION%.*}
-        GO_VERSION_PREVIOUS="${GO_MINOR_VERSION%.*}.$((${GO_MINOR_VERSION#*.}-1))"
-        echo "Previous version ${GO_VERSION_PREVIOUS}"
+        GO_MAJOR_VERSION=${GO_VERSION%.*}
+        echo "go-major-version=${GO_MAJOR_VERSION}" >> "${GITHUB_OUTPUT}"
+        GO_MAJOR_VERSION_PREVIOUS="${GO_MAJOR_VERSION%.*}.$((${GO_MAJOR_VERSION#*.}-1))"
+        echo "Previous version: ${GO_MAJOR_VERSION_PREVIOUS}"
 
-    - name: 'Check if Go version is an LTS release'
-      id: check-lts
+    - name: 'Check if Go version is a stable release'
+      id: check-stable
       shell: bash
       run: |
         GO_VERSION=${{ steps.get-go-version.outputs.go-version }}
-        GO_MINOR_VERSION=${GO_VERSION%.*}
+        GO_MAJOR_VERSION=${{ steps.get-go-version.outputs.go-major-version }}
         versions=$(curl -s 'https://api.github.com/repos/golang/go/git/refs/tags' | jq -r '.[].ref' | grep -o 'refs/tags/go[0-9\.]*' | grep -E 'go[0-9]+\.[0-9]+\.[1-9][0-9]*$' | sed 's_refs/tags/__')
         latest_versions=$(echo "$versions" | grep -o 'go[0-9]\+\.[0-9]\+' | sed 's/go//' | sort -uV | tail -2)
         
-        lts=false
+        stable=false
         needs_bump=false
         for version in $latest_versions; do
           echo "$versions" | grep "$version"
-          if [ "$version" = "$GO_MINOR_VERSION" ]; then
-            echo "$GO_VERSION is part of an LTS release of $GO_MINOR_VERSION"
-            lts=true
-            echo "lts=${lts}" >> "${GITHUB_OUTPUT}"
+          if [ "$version" = "$GO_MAJOR_VERSION" ]; then
+            echo "$GO_VERSION is a minor release of $GO_MAJOR_VERSION"
+            stable=true
+            echo "stable=${stable}" >> "${GITHUB_OUTPUT}"
             break
           fi
         done
-        if [ "$lts" = "false" ]; then
-          echo "$GO_VERSION is NOT part of an LTS release of $GO_MINOR_VERSION"
+        if [ "$stable" = "false" ]; then
+          echo "$GO_VERSION is NOT a minor release of $GO_MAJOR_VERSION"
           exit 1
         fi
 
-        latest_patch_version=$(echo "$versions" | grep "$GO_MINOR_VERSION"| sed 's/go//' | sort -V | tail -1)
+        latest_patch_version=$(echo "$versions" | grep "$GO_MAJOR_VERSION"| sed 's/go//' | sort -V | tail -1)
         if [ "$latest_patch_version" != "$GO_VERSION" ]; then
-          echo "$GO_VERSION needs to be bumped to $latest_patch_version"
+          echo "$GO_VERSION can be bumped to $latest_patch_version"
           needs_bump=true
           echo "needs-bump=${needs_bump}" >> "${GITHUB_OUTPUT}"
           echo "latest-patch-version=${latest_patch_version}" >> "${GITHUB_OUTPUT}"
         fi
 
-    - name: 'Push changes to bump go version and sdlibs'
+    - name: 'Push changes to bump go version and stdlibs'
       id: git-push-changes
       shell: bash
-      if: steps.check-lts.outputs.lts == 'true' && steps.check-lts.outputs.needs-bump == 'true'
+      if: steps.check-stable.outputs.stable == 'true' && steps.check-stable.outputs.needs-bump == 'true'
       run: |
-        echo "Starting to Push changes to bump go version and sdlibs"
+        echo "Starting to push changes to bump go version and sdlibs"
         git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git config --local user.name "github-actions[bot]"  
 
-        BRANCH_NAME="bump-go-${{ steps.check-lts.outputs.latest-patch-version }}"
+        BRANCH_NAME="bump-go/${{ steps.check-stable.outputs.latest-patch-version }}"
         echo "branch-name=${BRANCH_NAME}" >> "${GITHUB_OUTPUT}"
 
         git fetch
@@ -99,23 +100,23 @@ runs:
         fi
         git checkout -b "$BRANCH_NAME"
 
-        echo "${{ steps.check-lts.outputs.latest-patch-version }}" > .go-version
+        echo "${{ steps.check-stable.outputs.latest-patch-version }}" > .go-version
 
         find . -name go.mod -execdir sh -c 'awk "/golang.org\/x/ {print \$1}" go.mod | grep "golang.org/x" | while read -r line; do go get $line@latest; done' \;
 
         find . -name go.mod -execdir go mod tidy \;
 
         git add .
-        git commit -m "Bump go version to ${{ steps.check-lts.outputs.latest-patch-version }}"
+        git commit -m "build(deps): bump go version to ${{ steps.check-stable.outputs.latest-patch-version }}"
         git push origin "$BRANCH_NAME"
 
     - name: 'Create PR to bump go version and stdlibs'
       shell: bash
-      if: steps.check-lts.outputs.lts == 'true' && steps.check-lts.outputs.needs-bump == 'true'
+      if: steps.check-stable.outputs.stable == 'true' && steps.check-stable.outputs.needs-bump == 'true'
       env:
         INPUT_REVIEWER: ${{ inputs.pr_reviewer }}
         GITHUB_TOKEN: ${{ inputs.github_token }}
       run: |
         BRANCH_NAME=${{ steps.git-push-changes.outputs.branch-name }}
-        gh pr create --base main --head "$BRANCH_NAME" --title "[auto] Bump go version to ${{ steps.check-lts.outputs.latest-patch-version }}" --body "Bump go version to ${{ steps.check-lts.outputs.latest-patch-version }}" --reviewer "${INPUT_REVIEWER}"
+        gh pr create --base main --head "$BRANCH_NAME" --title "[bump-go] Bump go version to ${{ steps.check-stable.outputs.latest-patch-version }}" --body 'Bump go version to [${{ steps.check-stable.outputs.latest-patch-version }}](https://go.dev/doc/devel/release#go${{ steps.get-go-version.outputs.go-major-version }}.minor)' --reviewer "${INPUT_REVIEWER}"
         echo "Created PR to bump go version and stdlibs"


### PR DESCRIPTION
Swap references to "LTS" with "major"/"stable", and update "minor" to "major" to reflect Go's off-by-one semver scheme.

Also make some minor adjustments to branch name, commit message, and PR
title to align with common conventions.